### PR TITLE
Remove "Open New Tab" feature

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -175,7 +175,7 @@ import { getUploadOnceAvailable } from "./platform";
       properties: ["openFile", "multiSelections"],
     });
     for (const filePath of filePaths) {
-      receive({ path: filePath, opensNewTab: false, checksFileID: false });
+      receive({ path: filePath, checksFileID: false });
     }
   };
 
@@ -231,10 +231,6 @@ import { getUploadOnceAvailable } from "./platform";
         ...uploadedList,
       ].slice(0, 10);
       setTrayMenu();
-      if (event.opensNewTab) {
-        shell.openExternal(firstUploadResponse.permalink_url);
-      }
-
       // Store minimal data
       uploadedStore.set(fileID, true);
     } catch (exception) {

--- a/src/renderer/settings.tsx
+++ b/src/renderer/settings.tsx
@@ -66,33 +66,14 @@ const App: FunctionComponent = () => {
             <thead>
               <tr>
                 <th className="border-b font-medium p-2 text-left">Path</th>
-                <th className="border-b font-medium p-2">Open new tab</th>
                 <th className="border-b font-medium p-2"></th>
               </tr>
             </thead>
 
             <tbody>
-              {watchlist.map(({ path, opensNewTab }, index) => (
+              {watchlist.map(({ path }, index) => (
                 <tr key={index}>
                   <td className="border-b border-slate-100 p-2">{path}</td>
-
-                  <td className="border-b border-slate-100 p-2 text-center">
-                    <input
-                      type="checkbox"
-                      checked={opensNewTab}
-                      onChange={(event) => {
-                        setWatchlist((prevWatchlist) => [
-                          ...prevWatchlist.slice(0, index),
-                          {
-                            ...prevWatchlist[index],
-                            opensNewTab: event.target.checked,
-                          },
-                          ...prevWatchlist.slice(index + 1),
-                        ]);
-                      }}
-                    />
-                  </td>
-
                   <td className="border-b border-slate-100 p-2 text-center">
                     <button
                       type="button"
@@ -118,7 +99,7 @@ const App: FunctionComponent = () => {
               const paths = await electronAPI.selectDirectory();
               setWatchlist((prevWatchlist) => [
                 ...prevWatchlist,
-                ...paths.map((path) => ({ path, opensNewTab: false })),
+                ...paths.map((path) => ({ path })),
               ]);
             }}
           >

--- a/src/watch-list.ts
+++ b/src/watch-list.ts
@@ -1,6 +1,7 @@
 type WatchV1 = string;
 export interface WatchV2 {
   path: string;
+  opensNewTab?: never;
 }
 export type Watch = WatchV1 | WatchV2;
 

--- a/src/watch-list.ts
+++ b/src/watch-list.ts
@@ -1,11 +1,10 @@
 type WatchV1 = string;
 export interface WatchV2 {
   path: string;
-  opensNewTab: boolean;
 }
 export type Watch = WatchV1 | WatchV2;
 
 export const toWatchlistV2 = (watchlist: (WatchV1 | WatchV2)[]): WatchV2[] =>
   watchlist.map((item) =>
-    typeof item === "string" ? { path: item, opensNewTab: false } : item
+    typeof item === "string" ? { path: item } : item
   );


### PR DESCRIPTION
This PR removes the "Open New Tab" feature from the application.

Changes:
1. Make `opensNewTab` property type `never` in `WatchV2` interface for backward compatibility
2. Remove "Open new tab" column and checkbox from settings page
3. Remove browser opening functionality from main process

All tests are passing.

Note: The `opensNewTab` property is kept as an optional `never` type to maintain backward compatibility with old settings that might still exist on old devices.